### PR TITLE
Nullsafety fixes / Return Types

### DIFF
--- a/packages/dart/lib/src/objects/parse_installation.dart
+++ b/packages/dart/lib/src/objects/parse_installation.dart
@@ -61,7 +61,7 @@ class ParseInstallation extends ParseObject {
 
   /// Gets the current installation from storage
   static Future<ParseInstallation> currentInstallation() async {
-    return (await (_getFromLocalStore() as FutureOr<ParseInstallation>?)) ?? (await _createInstallation());
+    return (await _getFromLocalStore()) ?? (await _createInstallation());
   }
 
   /// Updates the installation with current device data

--- a/packages/dart/lib/src/storage/core_store_sem_impl.dart
+++ b/packages/dart/lib/src/storage/core_store_sem_impl.dart
@@ -6,8 +6,9 @@ class CoreStoreSembastImp implements CoreStore {
 
   static CoreStoreSembastImp? _instance;
 
-  static Future<CoreStore> getInstance(String dbPath,
-      {DatabaseFactory? factory, String password = 'flutter_sdk'}) async {
+  static Future<CoreStoreSembastImp> getInstance(String dbPath,
+      {DatabaseFactory? factory, String? password}) async {
+    password ??= 'flutter_sdk';
     if (_instance == null) {
       factory ??= !parseIsWeb ? databaseFactoryIo : databaseFactoryWeb;
       assert(() {
@@ -58,31 +59,31 @@ class CoreStoreSembastImp implements CoreStore {
 
   @override
   Future<bool?> getBool(String key) async {
-    final bool? storedItem = await (get(key));
+    final bool? storedItem = await get(key);
     return storedItem;
   }
 
   @override
   Future<double?> getDouble(String key) async {
-    final double? storedItem = await (get(key));
+    final double? storedItem = await get(key);
     return storedItem;
   }
 
   @override
   Future<int?> getInt(String key) async {
-    final int? storedItem = await (get(key));
+    final int? storedItem = await get(key);
     return storedItem;
   }
 
   @override
   Future<String?> getString(String key) async {
-    final String? storedItem = await (get(key));
+    final String? storedItem = await get(key);
     return storedItem;
   }
 
   @override
   Future<List<String>?> getStringList(String key) async {
-    final List<String>? storedItem = await (get(key));
+    final List<String>? storedItem = await get(key);
     return storedItem;
   }
 

--- a/packages/flutter/lib/parse_server_sdk.dart
+++ b/packages/flutter/lib/parse_server_sdk.dart
@@ -39,7 +39,7 @@ class Parse extends sdk.Parse
   /// [appName], [appVersion] and [appPackageName] are automatically set on Android and IOS, if they are not defined. You should provide a value on web.
   /// [fileDirectory] is not used on web
   @override
-  Future<sdk.Parse> initialize(
+  Future<Parse> initialize(
     String appId,
     String serverUrl, {
     bool debug = false,
@@ -95,7 +95,7 @@ class Parse extends sdk.Parse
           (!sdk.parseIsWeb ? (await getTemporaryDirectory()).path : null),
       appResumedStream: appResumedStream ?? _appResumedStreamController.stream,
       clientCreator: clientCreator,
-    );
+    ) as Parse;
   }
 
   final StreamController<void> _appResumedStreamController =
@@ -153,26 +153,26 @@ class CoreStoreSembastImp implements sdk.CoreStoreSembastImp {
 
   static sdk.CoreStore? _sembastImp;
 
-  static Future<sdk.CoreStore> getInstance(
-      {DatabaseFactory? factory, String password = 'flutter_sdk'}) async {
-    _sembastImp ??= await (sdk.CoreStoreSembastImp.getInstance(
+  static Future<CoreStoreSembastImp> getInstance(
+      {DatabaseFactory? factory, String? password}) async {
+    _sembastImp ??= await sdk.CoreStoreSembastImp.getInstance(
         await dbDirectory(),
         factory: factory,
-        password: password));
+        password: password);
     return CoreStoreSembastImp._();
   }
 
   @override
   Future<bool> clear() async {
     await _sembastImp!.clear();
-    return Future<bool>.value(true);
+    return true;
   }
 
   @override
   Future<bool> containsKey(String key) => _sembastImp!.containsKey(key);
 
   @override
-  Future<dynamic?> get(String key) => _sembastImp!.get(key);
+  Future<dynamic> get(String key) => _sembastImp!.get(key);
 
   @override
   Future<bool?> getBool(String key) => _sembastImp!.getBool(key);

--- a/packages/flutter/lib/src/storage/core_store_sp_impl.dart
+++ b/packages/flutter/lib/src/storage/core_store_sp_impl.dart
@@ -5,7 +5,8 @@ class CoreStoreSharedPrefsImp implements sdk.CoreStore {
 
   static CoreStoreSharedPrefsImp? _instance;
 
-  static Future<sdk.CoreStore> getInstance({SharedPreferences? store}) async {
+  static Future<CoreStoreSharedPrefsImp> getInstance(
+      {SharedPreferences? store}) async {
     if (_instance == null) {
       store ??= await SharedPreferences.getInstance();
       _instance = CoreStoreSharedPrefsImp._internal(store);


### PR DESCRIPTION
- Nullsafety fixes
- Fix return type in CoreStoreSembastImp.getInstance
- Fix return type in CoreStoreSharedPrefsImp,getInstance
- Fix return type Parse.initialize
- Removing unnecessary parentheses